### PR TITLE
DI-3775 undo upgrade of jersey and reflections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
-            <version>1.6.9</version>
+            <version>1.6.2</version>
             <!-- Causes runtime issues with jakarta.validation:validation-api in dropwizard-core -->
             <exclusions>
                 <exclusion>

--- a/src/main/java/io/federecio/dropwizard/swagger/FastBeanConfig.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/FastBeanConfig.java
@@ -59,11 +59,9 @@ public class FastBeanConfig extends BeanConfig {
      * set input filter: speed up scanning and remove warnings on fat jars
      */
     if (!allowAllPackages) {
-      final FilterBuilder fb = new FilterBuilder();
-      for (final String p : acceptablePackages) {
-        fb.includePackage(p);
-      }
-      config.setInputsFilter(fb);
+      config.setInputsFilter(
+          new FilterBuilder()
+              .includePackage(acceptablePackages.toArray(new String[acceptablePackages.size()])));
     }
 
     final Reflections reflections = new Reflections(config);


### PR DESCRIPTION
revert the upgrade to jersey and reflections libraries, since it doesn't play well with other versions of dropwizard libraries and the projects that use dropwizard.

Build: https://jenkins.ci.sonatype.dev/job/data/job/data-identity/job/dropwizard-swagger/job/PR_Build/job/DI-3775-undo-jersey-reflections-upgrade/